### PR TITLE
Return socketcluster server for export function

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,7 +1,7 @@
 module.exports = function(argv) {
   var SocketCluster = require('socketcluster').SocketCluster;
 
-  var socketCluster = new SocketCluster({
+  return new SocketCluster({
     host: argv.hostname || null,
     port: Number(argv.port) || 8000,
     workerController: __dirname + '/worker.js',


### PR DESCRIPTION
so we can use `require('remotedev-server')(options).on('ready', () => ...)`.
