### PR TITLE
Added support for SocketCluster https options

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -5,6 +5,12 @@ module.exports = function(argv) {
     host: argv.hostname || null,
     port: Number(argv.port) || 8000,
     workerController: __dirname + '/worker.js',
-    allowClientPublish: false
+    allowClientPublish: false,
+    protocol: argv.protocol || 'http',
+    protocolOptions: !(argv.protocol === 'https') ? null : {
+      key: argv.key || null,
+      cert: argv.cert || null,
+      passphrase: argv.passphrase || null
+    }
   });
 };


### PR DESCRIPTION
Added the following cli flags:

```
--protocol   [protocol="http"]
--key        [protocolOptions.key]
--cert       [protcolOptions.cert]
--passphrase [protcolOptions.passphrase]
```

Example Usage:

``` bash
remotedev --protocol=https --key="$(< ./path/to/key.pem)" --cert="$(< ./path/to/cert.pem)" --passphrase=foo
```
