### PR TITLE
Support use `remotedev` npm package field

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -2,15 +2,15 @@ module.exports = function(argv) {
   var SocketCluster = require('socketcluster').SocketCluster;
 
   return new SocketCluster({
-    host: argv.hostname || null,
-    port: Number(argv.port) || 8000,
+    host: argv.hostname || process.env.npm_package_remotedev_hostname || null,
+    port: Number(argv.port || process.env.npm_package_remotedev_port) || 8000,
     workerController: __dirname + '/worker.js',
     allowClientPublish: false,
-    protocol: argv.protocol || 'http',
+    protocol: argv.protocol || process.env.npm_package_remotedev_protocol || 'http',
     protocolOptions: !(argv.protocol === 'https') ? null : {
-      key: argv.key || null,
-      cert: argv.cert || null,
-      passphrase: argv.passphrase || null
+      key: argv.key || process.env.npm_package_remotedev_key || null,
+      cert: argv.cert || process.env.npm_package_remotedev_cert || null,
+      passphrase: argv.passphrase || process.env.npm_package_remotedev_passphrase || null
     }
   });
 };


### PR DESCRIPTION
We can use `remotedev` in package.json:

``` js
{
  ...,
  "remotedev": {
    "hostname": "192.168.0.10",
    "port": 8888,
    ...
  }
}
```

If we let remotedev-server as a devDependency, it would be convenient use `remote-redux-devtools` with same options (`require('../package.json').remotedev`).
