### PR TITLE
Support RN ^0.31 inject server

### DIFF
--- a/bin/remotedev.js
+++ b/bin/remotedev.js
@@ -31,13 +31,16 @@ function getModuleName(type) {
   }
 }
 
-function getModulePath(type) {
-  var moduleName = getModuleName(type);
+function getModulePath(moduleName) {
   return path.join(process.cwd(), 'node_modules', moduleName);
 }
 
 if (argv.revert) {
-  var pass = injectServer.revert(getModulePath(argv.revert));
+  var moduleName = getModuleName(argv.revert);
+  var pass = injectServer.revert(
+    getModulePath(moduleName),
+    moduleName
+  );
   var msg = 'Revert injection of RemoteDev server from React Native local server';
   log(pass, msg + (!pass ? ', the file `' + injectServer.fullPath + '` not found.' : '.'));
 
@@ -46,7 +49,12 @@ if (argv.revert) {
 
 if (argv.injectserver) {
   var options = getOptions(argv);
-  var pass = injectServer.inject(getModulePath(argv.injectserver), options);
+  var moduleName = getModuleName(argv.injectserver)
+  var pass = injectServer.inject(
+    getModulePath(moduleName),
+    options,
+    moduleName
+  );
   var msg = 'Inject RemoteDev server into React Native local server';
   log(pass, msg + (pass ? '.' : ', the file `' + injectServer.fullPath + '` not found.'));
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",
     "repeat-string": "^1.5.4",
+    "semver": "^5.3.0",
     "socketcluster": "^4.3.1"
   }
 }


### PR DESCRIPTION
React Native v0.31 has big changes in [local-cli/server/server.js](https://github.com/facebook/react-native/blob/master/local-cli/server/server.js), we should check RN version for `injectserver` and `revert`.
