### PR TITLE
Support new `react-native-macos` package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Change `hostname` and `port` to the values you want.
 }
 ```
 
-The `injectserver` value can be `reactnative` or `desktop` ([react-native-desktop](https://github.com/ptmt/react-native-desktop)), it used `reactnative` by default.
+The `injectserver` value can be `reactnative` or `macos` ([react-native-macos](https://github.com/ptmt/react-native-macos)), it used `reactnative` by default.
 
 Then, we can start React Native server and RemoteDev server with one command:
 


### PR DESCRIPTION
[react-native-macos](https://github.com/ptmt/react-native-macos) is renamed from `react-native-desktop`.
- Add the `macos` type for `injectserver` or `revert` flag
- Keep the `desktop` type, if cannot find module `react-native-desktop`, then use `react-native-macos` as module name
