### PR TITLE
updated socketcluster to 5.9.1, due to removal of uws 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "object-assign": "^4.0.0",
     "repeat-string": "^1.5.4",
     "semver": "^5.3.0",
-    "socketcluster": "^5.0.4"
+    "socketcluster": "^5.9.1"
   }
 }


### PR DESCRIPTION
It looks like uws v0.13.0 was unpublished so I've update socketcluster to 5.9.1 which uses uws 0.14.1