### PR TITLE
Support RN >= 0.44.0-rc.0 for injectserver

### DIFF
--- a/bin/injectServer.js
+++ b/bin/injectServer.js
@@ -8,7 +8,8 @@ var endFlag = '/* ' + name + ' end */';
 var serverFlags = {
   'react-native': {
     '0.0.1': '    _server(argv, config, resolve, reject);',
-    '0.31.0': "  runServer(args, config, () => console.log('\\nReact packager ready.\\n'));"
+    '0.31.0': "  runServer(args, config, () => console.log('\\nReact packager ready.\\n'));",
+    '0.44.0-rc.0': '  runServer(args, config, startedCallback, readyCallback);'
   },
   'react-native-desktop': {
     '0.0.1': '    _server(argv, config, resolve, reject);'


### PR DESCRIPTION
Add a flag for [this change](https://github.com/facebook/react-native/commit/b80e2c8799cc2ef76c77752bbf00be849b0be6b1#diff-4a892a6b8856f0253e2de7094e585ae6L65) from RN 0.44.