### PR TITLE
Support RN > 0.46.0-rc.0 for injectServer

### DIFF
--- a/bin/injectServer.js
+++ b/bin/injectServer.js
@@ -9,7 +9,8 @@ var serverFlags = {
   'react-native': {
     '0.0.1': '    _server(argv, config, resolve, reject);',
     '0.31.0': "  runServer(args, config, () => console.log('\\nReact packager ready.\\n'));",
-    '0.44.0-rc.0': '  runServer(args, config, startedCallback, readyCallback);'
+    '0.44.0-rc.0': '  runServer(args, config, startedCallback, readyCallback);',
+    '0.46.0-rc.0': '  runServer(runServerArgs, configT, startedCallback, readyCallback);'
   },
   'react-native-desktop': {
     '0.0.1': '    _server(argv, config, resolve, reject);'


### PR DESCRIPTION
Support the change from 0.46.0-rc.0 (this [commit](https://github.com/facebook/react-native/commit/c0e8d67e01a4622729d86ec9d639a9dcac3d2c54#diff-4a892a6b8856f0253e2de7094e585ae6R57)).

Thank you.
