### PR TITLE
Fix table creation

### DIFF
--- a/lib/db/migrations/index.js
+++ b/lib/db/migrations/index.js
@@ -54,11 +54,11 @@ exports.up = function(knex, Promise) {
       table.boolean('readOnly').defaultTo(false);
       table.uuid('userId');
       table.uuid('appId');
+      table.primary(['userId', 'appId']);
       table.foreign('userId')
         .references('id').inTable('remotedev_users').onDelete('CASCADE').onUpdate('CASCADE');
       table.foreign('appId')
         .references('id').inTable('remotedev_apps').onDelete('CASCADE').onUpdate('CASCADE');
-      table.primary(['userId', 'appId']);
     })
   ])
 };


### PR DESCRIPTION
After struggling with database versions and errors creating the tables, I've stabilized on the minimal changes set using MariaDB V10.0.30 (the latest my server allows). This also works in mySql V5.7.18.
Without this commit, the error is:

```
Knex:warning - migrations failed with error: alter table `remotedev_users_apps` add primary key `remotedev_users_apps_pkey`(`userId`, `appId`) - Cannot change column 'appId': used in a foreign key constraint 'remotedev_users_apps_appid_foreign'
{ Error: alter table `remotedev_users_apps` add primary key `remotedev_users_apps_pkey`(`userId`, `appId`) - Cannot change column 'appId': used in a foreign key constraint 'remotedev_users_apps_appid_foreign'
    at Error (native) code: 1832 }
```

I've just changed the order of the line:
`      table.primary(['userId', 'appId']);`
to be executed before creating the foreign references.

Thank you