### PR TITLE
fix database seeding second run.

### DIFF
--- a/lib/db/migrations/index.js
+++ b/lib/db/migrations/index.js
@@ -19,7 +19,7 @@ exports.up = function(knex, Promise) {
       table.timestamp('added').defaultTo(knex.fn.now());
       table.uuid('appId')
         .references('id')
-        .inTable('remotedev_apps')
+        .inTable('remotedev_apps').onDelete('CASCADE').onUpdate('CASCADE')
         .defaultTo('78626c31-e16b-4528-b8e5-f81301b627f4');
     }),
     knex.schema.createTable('remotedev_payloads', function(table){
@@ -29,7 +29,7 @@ exports.up = function(knex, Promise) {
       table.timestamp('added').defaultTo(knex.fn.now());
       table.uuid('reportId')
         .references('id')
-        .inTable('remotedev_reports');
+        .inTable('remotedev_reports').onDelete('CASCADE').onUpdate('CASCADE');
     }),
     knex.schema.createTable('remotedev_apps', function(table){
       table.uuid('id').primary();


### PR DESCRIPTION
With migrations enabled, after having at least one report on database, a second run of the remotedev-server produces the following error:

`Error: delete from `remotedev_apps` - Cannot delete or update a parent row: a foreign key constraint fails (`brickxpert`.`remotedev_reports`, CONSTRAINT `remotedev_reports_appid_foreign` FOREIGN KEY (`appId`) REFERENCES `remotedev_apps` (`id`))`

The present commit avoids that by adding some missing onDelete('CASCADE').

I also wonder why reference columns are created with two different methods:
```
table.uuid('appId').references('id').inTable('remotedev_apps')...
table.foreign('userId').references('id').inTable('remotedev_users')...
```

But I'm not experienced on Knex and maybe there are some subtleties that I'm not aware of. Maybe something to do with the order of table creation and dependency?

Thank you and regards