### PR TITLE
Fix installation error caused by uws

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "object-assign": "^4.0.0",
     "repeat-string": "^1.5.4",
     "semver": "^5.3.0",
-    "socketcluster": "^5.0.4"
+    "socketcluster": "^6.7.1"
   }
 }


### PR DESCRIPTION
With a fresh yarn or npm cache, `remotedev-server` cannot be installed. Yarn fails with 

    error An unexpected error occurred: "https://registry.yarnpkg.com/uws/-/uws-0.13.0.tgz: Request failed \"404 Not Found\"".


The problem is that `uws@0.13.0` has been removed from yarn/npm (they call it archived here https://github.com/uNetworking/uWebSockets/releases) and `socketcluster@5.x` depends on `uws@0.13.0`...

It doesn't look like the breaking changes in socketcluster@6 will have any effect. See https://github.com/SocketCluster/socketcluster/releases/tag/v6.0.1