### PR TITLE
Fix payload truncated

### DIFF
--- a/lib/db/migrations/index.js
+++ b/lib/db/migrations/index.js
@@ -6,9 +6,9 @@ exports.up = function(knex, Promise) {
       table.string('title');
       table.string('description');
       table.string('action');
-      table.text('payload');
-      table.text('preloadedState');
-      table.text('screenshot');
+      table.text('payload', 'longtext');
+      table.text('preloadedState', 'longtext');
+      table.text('screenshot', 'longtext');
       table.string('userAgent');
       table.string('version');
       table.string('user');


### PR DESCRIPTION
Change payload sql datatype to support big payloads.
In mysql the TEXT datatype only supports 64k bytes. I easily got the payload truncated.
