### PR TITLE
Update socketcluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "object-assign": "^4.0.0",
     "repeat-string": "^1.5.4",
     "semver": "^5.3.0",
-    "socketcluster": "^6.7.1"
+    "socketcluster": "^12.0.0"
   }
 }


### PR DESCRIPTION
Main motivation is to stop pulling in a legacy version of Hoek that is
vulnerable: https://nvd.nist.gov/vuln/detail/CVE-2018-3728

It would be nice if you could release a patch version to allow people to easily get this fix.