### PR TITLE
Hotfix: Proper server flag for React Native 0.57.0

### DIFF
--- a/bin/injectServer.js
+++ b/bin/injectServer.js
@@ -10,7 +10,8 @@ var serverFlags = {
     '0.0.1': '    _server(argv, config, resolve, reject);',
     '0.31.0': "  runServer(args, config, () => console.log('\\nReact packager ready.\\n'));",
     '0.44.0-rc.0': '  runServer(args, config, startedCallback, readyCallback);',
-    '0.46.0-rc.0': '  runServer(runServerArgs, configT, startedCallback, readyCallback);'
+    '0.46.0-rc.0': '  runServer(runServerArgs, configT, startedCallback, readyCallback);',
+    '0.57.0': '  runServer(args, configT);'
   },
   'react-native-desktop': {
     '0.0.1': '    _server(argv, config, resolve, reject);'


### PR DESCRIPTION

This PR adds support for React Native 0.57.0, by adding proper server flag to `injectServer.js`.
This fixes https://github.com/zalmoxisus/remotedev-server/issues/60 and https://github.com/facebook/react-native/issues/21054.

@zalmoxisus, please let me know if I should also bump the package version or direct this PR to another branch.